### PR TITLE
fixing Log4JShell vulnerability

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -45,7 +45,7 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.13.3"
+                "org.apache.logging.log4j:log4j-core:2.15.0"
                 //"io.opentelemetry:opentelemetry-bom:1.7.0"
                 //"io.opentelemetry:opentelemetry-api"
 


### PR DESCRIPTION
See Vulnerable Log4J version (CVE-2021-44228) #655.
According to Apache docs, this is fixed in log4j 2.15.0.

like described here: https://github.com/GoogleCloudPlatform/microservices-demo/pull/656

Fixes # .

Change summary:
- 


Remaining issues / concerns:
